### PR TITLE
Implement custom thread-local RNG and split scene gen from trace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,6 +715,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core 0.6.2",
+]
+
+[[package]]
 name = "rayon"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -771,6 +780,7 @@ dependencies = [
  "image",
  "palette",
  "rand 0.8.3",
+ "rand_xoshiro",
  "rayon",
  "vek",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 image = "0.23"
 palette = "0.5"
 rand = { version = "0.8.3", features = ["small_rng"] }
+rand_xoshiro = "0.6.0"
 rayon = "1.5.0"
 vek = "0.14.0"
 

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,18 +1,24 @@
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
-use rand::prelude::*;
-use rrt::tracescene;
+use rand::SeedableRng;
+use rrt::{chap12_scene, init_pool_with_rng, tracescene, RttRng};
 use std::time::Duration;
 
 pub fn criterion_benchmark(c: &mut Criterion) {
+  const NX: usize = 10;
+  const NY: usize = 10;
+  const NS: usize = 4;
+  let mut rng = RttRng::seed_from_u64(0);
+  let (scene, camera) = chap12_scene(NX, NY, &mut rng);
+  let pool = init_pool_with_rng(rng);
   c.bench_function("tracescene/10x10x4", move |b| {
-    const NX: usize = 10;
-    const NY: usize = 10;
-    const NS: usize = 4;
-    let mut rng = rand::rngs::SmallRng::seed_from_u64(0xC0DE_D09E);
     // tracescene returns a large Vec (the image), so use iter_batched to deal with the
     // memory drop. iter_with_large_drop is not suitable because the outputs are too large
     // to accumulate.
-    b.iter_batched(|| (), |_| tracescene(NX, NY, NS, &mut rng), BatchSize::SmallInput);
+    b.iter_batched(
+      || (),
+      |_| tracescene(NX, NY, NS, &scene, &camera, &pool),
+      BatchSize::SmallInput,
+    );
   });
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
-use rand::prelude::*;
-use rrt::tracescene;
+use rand::SeedableRng;
+use rrt::{chap12_scene, init_pool_with_rng, tracescene, RttRng};
 
 fn main() {
   const NX: usize = 1200;
@@ -8,9 +8,10 @@ fn main() {
 
   eprintln!("Rendering {} x {} image using {} samples.", NX, NY, NS);
 
-  let mut rng = rand::rngs::SmallRng::seed_from_u64(0xC0DE_D09E);
-
-  let pixels = tracescene(NX, NY, NS, &mut rng);
+  let mut rng = RttRng::seed_from_u64(0);
+  let (scene, camera) = chap12_scene(NX, NY, &mut rng);
+  let pool = init_pool_with_rng(rng);
+  let pixels = tracescene(NX, NY, NS, &scene, &camera, &pool);
   image::save_buffer(
     "o.ppm",
     &pixels[..],


### PR DESCRIPTION
This patch implements a custom thread-local RNG using Xoshiro128Plus.
This is the same RNG as rand::ThreadRNG, but it does not automatically
reseed and it allows explicit control over the initial seed, which is
important to have reproducible outputs for benchmarking.

The patch also splits scene generation and scene tracing to exclude
scene generation from benchmarking.

AMD Ryzen 9 3900X 12-Core Processor (AMD64 Family 23 Model 113 Stepping 0)

tracescene/10x10x4      time:   [193.07 us 193.55 us 194.06 us]
                        change: [-38.319% -38.103% -37.880%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  2 (2.00%) high severe